### PR TITLE
Support ImmutableJS: use getLocationState instead of getRouterState as mentioned in #140

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,11 @@ _Have an example to add? Send us a PR!_
 
 Call this to create a middleware that can be applied with Redux's `applyMiddleware` to allow actions to call history methods. The middleware will look for route actions created by `push`, `replace`, etc. and applies them to the history.
 
-#### `ReduxMiddleware.listenForReplays(store: ReduxStore, selectRouterState?: function)`
+#### `ReduxMiddleware.listenForReplays(store: ReduxStore, selectLocationState?: function)`
 
 By default, the syncing logic will not respond to replaying of actions, which means it won't work with projects like redux-devtools. Call this function on the middleware object returned from `syncHistory` and give it the store to listen to, and it will properly work with action replays. Obviously, you would do that after you have created the store and everything else has been set up.
 
-Supply an optional function `selectRouterState` to customize where to find the router state on your app state. It defaults to `state => state.routing`, so you would install the reducer under the name "routing". Feel free to change this to whatever you like.
+Supply an optional function `selectLocationState` to customize where to find the location state on your app state. It defaults to `state => state.routing.location`, so you would install the reducer under the name "routing". Feel free to change this to whatever you like.
 
 #### `ReduxMiddleware.unsubscribe()`
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
 export const TRANSITION = '@@router/TRANSITION'
 export const UPDATE_LOCATION = '@@router/UPDATE_LOCATION'
 
-const SELECT_STATE = state => state.routing
+const SELECT_LOCATION = state => state.routing.location
 
 function transition(method) {
   return arg => ({
@@ -71,12 +71,12 @@ export function syncHistory(history) {
   }
 
   middleware.listenForReplays =
-    (store, selectRouterState = SELECT_STATE) => {
-      const getRouterState = () => selectRouterState(store.getState())
-      const { location: initialLocation } = getRouterState()
+    (store, selectLocationState = SELECT_LOCATION) => {
+      const getLocationState = () => selectLocationState(store.getState())
+      const initialLocation = getLocationState()
 
       unsubscribeStore = store.subscribe(() => {
-        const { location } = getRouterState()
+        const location = getLocationState()
 
         // If we're resetting to the beginning, use the saved initial value. We
         // need to dispatch a new action at this point to populate the store


### PR DESCRIPTION
This works for me with custom reducer:
```js
import { UPDATE_LOCATION } from 'redux-simple-router'

const initialState = new Immutable.Map({
  location: undefined
})

export default function routeReducer(state = initialState, { type, payload: location }) {
  if (type !== UPDATE_LOCATION) {
    return state
  }

  return state.merge({ location })
}
```

and this `selectLocationState`

```js
  const selectLocationState = function (state) {
    const location = state.get('routing').get('location')
    return location ? location.toJS() : location
  }
```