### PR TITLE
Update usage example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,19 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import { createStore, combineReducers, applyMiddleware } from 'redux'
 import { Provider } from 'react-redux'
-import { Router, Route, browserHistory } from 'react-router'
+import { Router, Route } from 'react-router'
 import { syncHistory, routeReducer } from 'react-router-redux'
 import reducers from '<project-path>/reducers'
+import { createHistory } from 'history';
+
+const history = createHistory();
 
 const reducer = combineReducers(Object.assign({}, reducers, {
   routing: routeReducer
 }))
 
 // Sync dispatched route actions to the history
-const reduxRouterMiddleware = syncHistory(browserHistory)
+const reduxRouterMiddleware = syncHistory(history)
 const createStoreWithMiddleware = applyMiddleware(reduxRouterMiddleware)(createStore)
 
 const store = createStoreWithMiddleware(reducer)
@@ -72,7 +75,7 @@ reduxRouterMiddleware.listenForReplays(store)
 
 ReactDOM.render(
   <Provider store={store}>
-    <Router history={browserHistory}>
+    <Router history={history}>
       <Route path="/" component={App}>
         <Route path="foo" component={Foo}/>
         <Route path="bar" component={Bar}/>


### PR DESCRIPTION
Now you need to manually include `history` lib for creating history object. See [https://github.com/rackt/react-router/issues/1455#issuecomment-138295614](https://github.com/rackt/react-router/issues/1455#issuecomment-138295614) for more details