### PR TITLE
[WIP] Tweak the API to handle initial state correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,18 @@ const reducer = combineReducers(Object.assign({}, reducers, {
   routing: routeReducer
 }))
 
-// Sync dispatched route actions to the history
+// specify the history to listen to
 const reduxRouterMiddleware = syncHistory(browserHistory)
-const createStoreWithMiddleware = applyMiddleware(reduxRouterMiddleware)(createStore)
+const store = createStore(
+  reducer,
+  applyMiddleware(reduxRouterMiddleware)
+)
 
-const store = createStoreWithMiddleware(reducer)
-
-// Required for replaying actions from devtools to work
-reduxRouterMiddleware.listenForReplays(store)
+// begin syncing
+reduxRouterMiddleware.syncWith(store, {
+  urlToState: true, // route changes will appear in state
+  stateToUrl: false // set to true for time travel in DevTools
+})
 
 ReactDOM.render(
   <Provider store={store}>
@@ -140,7 +144,7 @@ Examples from the community:
 
 _Have an example to add? Send us a PR!_
 
-### API
+### API (TODO)
 
 #### `syncHistory(history: History) => ReduxMiddleware`
 

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -27,12 +27,18 @@ const DevTools = createDevTools(
   </DockMonitor>
 )
 
-const finalCreateStore = compose(
-  applyMiddleware(middleware),
-  DevTools.instrument()
-)(createStore)
-const store = finalCreateStore(reducer)
-middleware.listenForReplays(store)
+const store = createStore(
+  reducer,
+  compose(
+    applyMiddleware(middleware),
+    DevTools.instrument()
+  )
+)
+
+middleware.syncWith(store, {
+  urlToState: true,
+  stateToUrl: true
+})
 
 ReactDOM.render(
   <Provider store={store}>

--- a/examples/basic/app.js
+++ b/examples/basic/app.js
@@ -4,7 +4,7 @@ import DockMonitor from 'redux-devtools-dock-monitor'
 
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { applyMiddleware, compose, createStore, combineReducers } from 'redux'
+import { compose, createStore, combineReducers } from 'redux'
 import { Provider } from 'react-redux'
 import { Router, Route, IndexRoute } from 'react-router'
 import createHistory from 'history/lib/createHashHistory'
@@ -14,7 +14,10 @@ import * as reducers from './reducers'
 import { App, Home, Foo, Bar } from './components'
 
 const history = createHistory()
-const middleware = syncHistory(history)
+const enhancer = syncHistory(history, {
+  urlToState: true,
+  stateToUrl: true
+})
 const reducer = combineReducers({
   ...reducers,
   routing: routeReducer
@@ -30,15 +33,10 @@ const DevTools = createDevTools(
 const store = createStore(
   reducer,
   compose(
-    applyMiddleware(middleware),
+    enhancer,
     DevTools.instrument()
   )
 )
-
-middleware.syncWith(store, {
-  urlToState: true,
-  stateToUrl: true
-})
 
 ReactDOM.render(
   <Provider store={store}>

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -9,8 +9,8 @@
     "react-dom": "^0.14.2",
     "react-redux": "^4.0.0",
     "react-router": "^1.0.0",
-    "redux": "^3.0.4",
-    "react-router-redux": "^2.1.0"
+    "react-router-redux": "^2.1.0",
+    "redux": "^3.2.1"
   },
   "devDependencies": {
     "babel-core": "^6.1.21",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.4",
     "react": "^0.14.3",
-    "redux": "^3.0.4",
+    "redux": "^3.2.1",
     "redux-devtools": "^3.0.0",
     "redux-devtools-dock-monitor": "^1.0.1",
     "redux-devtools-log-monitor": "^1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -43,89 +43,98 @@ export function routeReducer(state = initialState, { type, payload: location }) 
 
 // Syncing
 
-export function syncHistory(history) {
-  let unsubscribeHistory, currentKey, unsubscribeStore
-  let connected = false, syncing = false
+export function syncHistory(history, {
+  urlToState = false,
+  stateToUrl = false,
+  selectLocationState = SELECT_LOCATION
+} = {}) {
+  if (!urlToState && !stateToUrl) {
+    return createStore => createStore
+  }
 
   history.listen(location => { initialState.location = location })()
 
-  function middleware() {
-    return next => action => {
-      if (action.type !== TRANSITION || !connected) {
-        return next(action)
+  let currentKey, syncing = false
+  let unsubscribeStore, unsubscribeHistory
+
+  const updateStoreOnHistoryChange = (store) => {
+    unsubscribeHistory = history.listen(location => {
+      currentKey = location.key
+      if (syncing) {
+        // Don't dispatch a new action if we're replaying location.
+        return
+      }
+
+      store.dispatch(updateLocation(location))
+    })
+  }
+  const updateHistoryOnStoreChange = (store) => {
+    const getLocationState = () => selectLocationState(store.getState())
+    const initialLocation = getLocationState()
+
+    const reconcileLocationWithState = () => {
+      const location = getLocationState()
+
+      // If we're resetting to the beginning, use the saved initial value. We
+      // need to dispatch a new action at this point to populate the store
+      // appropriately.
+      if (location.key === initialLocation.key) {
+        history.replace(initialLocation)
+        return
+      }
+
+      // Otherwise, if we need to update the history location, do so without
+      // dispatching a new action, as we're just bringing history in sync
+      // with the store.
+      if (location.key !== currentKey) {
+        syncing = true
+        history.transitionTo(location)
+        syncing = false
+      }
+    }
+
+    reconcileLocationWithState()
+    unsubscribeStore = store.subscribe(reconcileLocationWithState)
+  }
+
+  const enhancer = createStore => (reducer, initialState, enhancer) => {
+    const store = createStore(reducer, initialState, enhancer)
+    const { dispatch: originalDispatch } = store
+
+    const dispatch = (action) => {
+      if (action.type !== TRANSITION || !unsubscribeHistory) {
+        return originalDispatch(action)
       }
 
       const { payload: { method, args } } = action
       history[method](...args)
     }
-  }
 
-  middleware.syncWith =
-    (store, {
-      urlToState = false,
-      stateToUrl = false,
-      selectLocationState = SELECT_LOCATION
-    } = {}) => {
-      if (!urlToState && !stateToUrl) {
-        throw new Error(
-          'At least one of "urlToState" and "stateToUrl" options must be true.'
-        )
-      }
-
-      if (stateToUrl) {
-        const getLocationState = () => selectLocationState(store.getState())
-        const initialLocation = getLocationState()
-
-        const reconcileLocationWithState = () => {
-          const location = getLocationState()
-
-          // If we're resetting to the beginning, use the saved initial value. We
-          // need to dispatch a new action at this point to populate the store
-          // appropriately.
-          if (location.key === initialLocation.key) {
-            history.replace(initialLocation)
-            return
-          }
-
-          // Otherwise, if we need to update the history location, do so without
-          // dispatching a new action, as we're just bringing history in sync
-          // with the store.
-          if (location.key !== currentKey) {
-            syncing = true
-            history.transitionTo(location)
-            syncing = false
-          }
-        }
-
-        unsubscribeStore = store.subscribe(reconcileLocationWithState)
-        reconcileLocationWithState()
-      }
-
-      if (urlToState) {
-        unsubscribeHistory = history.listen(location => {
-          currentKey = location.key
-          if (syncing) {
-            // Don't dispatch a new action if we're replaying location.
-            return
-          }
-
-          store.dispatch(updateLocation(location))
-        })
-
-        connected = true
-      }
-
-      return () => {
-        if (stateToUrl) {
-          unsubscribeStore()
-        }
-
-        if (urlToState) {
-          unsubscribeHistory()
-          connected = false
-        }
-      }
+    if (stateToUrl) {
+      updateHistoryOnStoreChange(store)
     }
 
-  return middleware
+    if (urlToState) {
+      updateStoreOnHistoryChange(store)
+    }
+
+    return {
+      ...store,
+      dispatch
+    }
+  }
+
+  enhancer.dispose = () => {
+    if (unsubscribeStore) {
+      unsubscribeStore()
+      unsubscribeStore = null
+    }
+
+    if (unsubscribeHistory) {
+      unsubscribeHistory()
+      unsubscribeHistory = null
+    }
+  }
+
+  return enhancer
 }


### PR DESCRIPTION
I know this is going to be controversial..

I think it’s wrong that the middleware dispatches during its creation. We probably won't allow it in next versions of Redux anyway.

The fact that this dispatch happens too early also caused https://github.com/rackt/react-router-redux/issues/252. When the initial state is specified to the store *and* we “listen to replays”, we want the state to be the source of truth in the absence of user action. So if we load a location from localStorage and pass it into the initial state, **whether with devtools or not**, we want the URL to be set from it.

Since we need to extract a method to cause the initial dispatch anyway, I thought I might as well unite these two methods and turn them into options:

```js
middleware.syncWith(store, {
  urlToState: true, // reflect URL changes in the state (useful in app)
  stateToUrl: false // reflect state changes in the URL (useful for replays, DevTools, etc)
})
```

I know not everybody is a fan of named arguments so I’m very open to suggestions here. My reasoning for uniting these two methods was the fact that:

* You *have to* call them in the right order (or we need to implement safeguards)
* You never need to call them twice

Therefore having to call one or two methods *just to get the thing working* seems like overkill. Additionally, named arguments explain *what actually happens* in very straightforward two-way binding terms, which is what this library actually is: two-way bindings from URL to a state field.

If you think this API sucks I’ll be happy to rewrite this to your API of choice. The primary purpose of this PR is still to fix #252, and I added a couple of new tests verifying that it is indeed now fixed.

This PR updates tests, example, and first part of the README. I am happy to update the API usage part when/if we agree on the API.