### PR TITLE
rename UPDATE_LOCATION to CALL_HISTORY_METHOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ function MyComponent({ dispatch }) {
 }
 ```
 
-This will change the state, which will trigger a change in react-router. Additionally, if you want to respond to the path update action, just handle the `UPDATE_LOCATION` constant that we provide:
+This will change the state, which will trigger a change in react-router. Additionally, if you want to respond to the path update action, just handle the `CALL_HISTORY_METHOD` constant that we provide:
 
 ```js
-import { UPDATE_LOCATION } from 'react-router-redux'
+import { CALL_HISTORY_METHOD } from 'react-router-redux'
 
 function update(state, action) {
   switch(action.type) {
-  case UPDATE_LOCATION:
+  case CALL_HISTORY_METHOD:
     // do something here
   }
 }
@@ -142,7 +142,7 @@ A reducer function that keeps track of the router state. You must add this reduc
 
 **Warning:** It is a bad pattern to use `react-redux`'s `connect` decorator to map the state from this reducer to props on your `Route` components. This can lead to infinite loops and performance problems. `react-router` already provides this for you via `this.props.location`.
 
-#### `UPDATE_LOCATION`
+#### `CALL_HISTORY_METHOD`
 
 An action type that you can listen for in your reducers to be notified of route updates.
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -3,11 +3,11 @@
  * If you're writing a middleware to watch for navigation events, be sure to
  * look for actions of this type.
  */
-export const UPDATE_LOCATION = '@@router/UPDATE_LOCATION'
+export const CALL_HISTORY_METHOD = '@@router/CALL_HISTORY_METHOD'
 
 function updateLocation(method) {
   return (...args) => ({
-    type: UPDATE_LOCATION,
+    type: CALL_HISTORY_METHOD,
     payload: { method, args }
   })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ export syncHistoryWithStore from './sync'
 export { LOCATION_CHANGE, routerReducer } from './reducer'
 
 export {
-  UPDATE_LOCATION,
+  CALL_HISTORY_METHOD,
   push, replace, go, goBack, goForward,
   routeActions
 } from './actions'

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,13 +1,13 @@
-import { UPDATE_LOCATION } from './actions'
+import { CALL_HISTORY_METHOD } from './actions'
 
 /**
- * This middleware captures UPDATE_LOCATION actions to redirect to the
+ * This middleware captures CALL_HISTORY_METHOD actions to redirect to the
  * provided history object. This will prevent these actions from reaching your
  * reducer or any middleware that comes after this one.
  */
 export default function routerMiddleware(history) {
   return () => next => action => {
-    if (action.type !== UPDATE_LOCATION) {
+    if (action.type !== CALL_HISTORY_METHOD) {
       return next(action)
     }
 

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -1,7 +1,7 @@
 import expect from 'expect'
 
 import {
-  UPDATE_LOCATION,
+  CALL_HISTORY_METHOD,
   push, replace, go, goBack, goForward
 } from '../src/actions'
 
@@ -10,7 +10,7 @@ describe('routeActions', () => {
   describe('push', () => {
     it('creates actions', () => {
       expect(push('/foo')).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'push',
           args: [ '/foo' ]
@@ -18,7 +18,7 @@ describe('routeActions', () => {
       })
 
       expect(push({ pathname: '/foo', state: { the: 'state' } })).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'push',
           args: [ {
@@ -29,7 +29,7 @@ describe('routeActions', () => {
       })
 
       expect(push('/foo', 'baz', 123)).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'push',
           args: [ '/foo' , 'baz', 123 ]
@@ -41,7 +41,7 @@ describe('routeActions', () => {
   describe('replace', () => {
     it('creates actions', () => {
       expect(replace('/foo')).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'replace',
           args: [ '/foo' ]
@@ -49,7 +49,7 @@ describe('routeActions', () => {
       })
 
       expect(replace({ pathname: '/foo', state: { the: 'state' } })).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'replace',
           args: [ {
@@ -64,7 +64,7 @@ describe('routeActions', () => {
   describe('go', () => {
     it('creates actions', () => {
       expect(go(1)).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'go',
           args: [ 1 ]
@@ -76,7 +76,7 @@ describe('routeActions', () => {
   describe('goBack', () => {
     it('creates actions', () => {
       expect(goBack()).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'goBack',
           args: []
@@ -88,7 +88,7 @@ describe('routeActions', () => {
   describe('goForward', () => {
     it('creates actions', () => {
       expect(goForward()).toEqual({
-        type: UPDATE_LOCATION,
+        type: CALL_HISTORY_METHOD,
         payload: {
           method: 'goForward',
           args: []


### PR DESCRIPTION
Following comments on #259.

> I'm not sure keeping the old name is worth the confusion generated by introducing two actions.
>
>Especially now that we encourage calling history methods directly, people relying on the old action and thinking they don't need to change their analytics code will have broken code because direct history calls will not invoke the new action.
>
>I think CALL_HISTORY_METHOD might be the best choice here. It makes it clear this is not intended for analytics.
- @gaearon 

Also, let's not forget the the name already changed once in the past... 
> * `UPDATE_PATH` is now `UPDATE_LOCATION`.